### PR TITLE
Støtte ident endringer.

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/mottak/tjenester/PersondataMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mottak/tjenester/PersondataMottak.kt
@@ -25,7 +25,7 @@ internal class PersondataMottak(
         River(rapidsConnection).apply {
             validate { it.requireValue("@event_name", "behov") }
             validate { it.require("@opprettet", JsonNode::asLocalDateTime) }
-            validate { it.require(løsning, {}) }
+            validate { it.requireKey(løsning) }
             validate { it.requireKey("journalpostId") }
         }.register(this)
     }
@@ -41,7 +41,7 @@ internal class PersondataMottak(
                 aktivitetslogg = Aktivitetslogg(),
                 journalpostId = journalpostId,
                 aktørId = persondata["aktørId"].asText(),
-                fødselsnummer = persondata["fødselsnummer"].asText(),
+                ident = persondata["fødselsnummer"].asText(),
                 diskresjonskode = persondata["diskresjonskode"].textValue(),
                 navn = persondata["navn"].asText(),
                 norskTilknytning = persondata["norskTilknytning"].asBoolean()

--- a/mediator/src/main/resources/db/migration/V7__PERSON.sql
+++ b/mediator/src/main/resources/db/migration/V7__PERSON.sql
@@ -1,0 +1,10 @@
+ALTER TABLE person_v1
+DROP CONSTRAINT IF EXISTS  person_v1_aktørid_key;
+ALTER TABLE person_v1
+DROP CONSTRAINT IF EXISTS  person_v1_fødselsnummer_key;
+
+ALTER TABLE person_v1
+RENAME COLUMN fødselsnummer TO ident;
+
+ALTER TABLE person_v1
+ADD CONSTRAINT person_v1_unique UNIQUE (ident, aktørid)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/TestHelper.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/TestHelper.kt
@@ -1,12 +1,15 @@
 package no.nav.dagpenger
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.dagpenger.mottak.PersonTestData.GENERERT_DNUMMER
+import no.nav.dagpenger.mottak.PersonTestData.GENERERT_FØDSELSNUMMER
 import no.nav.dagpenger.mottak.serder.InnsendingData
 import java.time.LocalDateTime
 
 internal val journalpostId = "187689"
 internal val journalpostStatus = "aktiv"
-internal val fnr = "12345678910"
+internal val fnr = GENERERT_FØDSELSNUMMER
+internal val dnr = GENERERT_DNUMMER
 internal val registrertdato = LocalDateTime.now()
 private val dokumenter = listOf(
     InnsendingData.JournalpostData.DokumentInfoData(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mottak/PersonTestData.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mottak/PersonTestData.kt
@@ -1,0 +1,16 @@
+package no.nav.dagpenger.mottak
+
+import no.bekk.bekkopen.person.FodselsnummerCalculator
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
+
+object PersonTestData {
+    private val dato = Date.from(
+        LocalDate.now().minusYears(20).atStartOfDay(
+            ZoneId.systemDefault()
+        ).toInstant()
+    )
+    val GENERERT_FØDSELSNUMMER by lazy { FodselsnummerCalculator.getFodselsnummerForDate(dato).toString() }
+    val GENERERT_DNUMMER by lazy { FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(dato).first().toString() }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mottak/api/InnsendingApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mottak/api/InnsendingApiTest.kt
@@ -6,8 +6,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.TestApplicationRequest
 import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
-import io.ktor.util.InternalAPI
-import io.ktor.util.encodeBase64
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -20,6 +18,7 @@ import org.apache.kafka.clients.producer.MockProducer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.util.Base64
 
 internal class InnsendingApiTest {
 
@@ -71,10 +70,9 @@ internal class InnsendingApiTest {
         }
     }
 
-    @OptIn(InternalAPI::class)
     private fun withAuth(): TestApplicationRequest.() -> Unit = {
         val up = "${okCredential.first}:${okCredential.second}"
-        val encoded = up.toByteArray(Charsets.ISO_8859_1).encodeBase64()
+        val encoded = String(Base64.getEncoder().encode(up.toByteArray(Charsets.ISO_8859_1)))
         addHeader(HttpHeaders.Authorization, "Basic $encoded")
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mottak/db/SkjemaTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mottak/db/SkjemaTest.kt
@@ -10,7 +10,7 @@ internal class SkjemaTest {
     @Test
     fun `riktig anntall migreringer`() {
         withCleanDb {
-            assertEquals(6, runMigration(dataSource))
+            assertEquals(7, runMigration(dataSource))
         }
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mottak/e2e/MediatorE2ETest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mottak/e2e/MediatorE2ETest.kt
@@ -1,8 +1,8 @@
 package no.nav.dagpenger.mottak.e2e
 
-import no.finn.unleash.FakeUnleash
 import no.nav.dagpenger.mottak.InnsendingMediator
 import no.nav.dagpenger.mottak.InnsendingTilstandType
+import no.nav.dagpenger.mottak.PersonTestData.GENERERT_FØDSELSNUMMER
 import no.nav.dagpenger.mottak.db.InnsendingPostgresRepository
 import no.nav.dagpenger.mottak.db.PostgresTestHelper
 import no.nav.dagpenger.mottak.db.runMigration
@@ -25,7 +25,6 @@ internal class MediatorE2ETest {
         runMigration(PostgresTestHelper.dataSource)
     }
     private val testObservatør = TestObservatør()
-    private val fakeUnleash = FakeUnleash().also { it.enableAll() }
     private val innsendingMediator = InnsendingMediator(
         innsendingRepository = innsendingRepository,
         rapidsConnection = testRapid,
@@ -191,7 +190,7 @@ internal class MediatorE2ETest {
             "Persondata": {
               "navn": "Test Testen",
               "aktørId": "tadda",
-              "fødselsnummer": "12345678910",
+              "fødselsnummer": "$GENERERT_FØDSELSNUMMER",
               "norskTilknytning": true,
               "diskresjonskode": null
             }

--- a/modell/build.gradle.kts
+++ b/modell/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     implementation(Jackson.core)
     implementation(Jackson.kotlin)
     implementation(Jackson.jsr310)
+    api("no.bekk.bekkopen:nocommons:0.12.0")
 
     testImplementation(Junit5.params)
     testImplementation(Mockk.mockk)

--- a/modell/src/main/kotlin/no/nav/dagpenger/mottak/InnsendingVisitor.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/mottak/InnsendingVisitor.kt
@@ -21,7 +21,7 @@ interface SøknadVisitor {
 }
 
 interface PersonVisitor {
-    fun visitPerson(navn: String, aktørId: String, fødselsnummer: String, norskTilknytning: Boolean, diskresjonskode: Boolean) {}
+    fun visitPerson(navn: String, aktørId: String, ident: String, norskTilknytning: Boolean, diskresjonskode: Boolean) {}
 }
 
 interface ArenaSakVisitor {

--- a/modell/src/test/kotlin/no/nav/dagpenger/mottak/PersonTestData.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/mottak/PersonTestData.kt
@@ -1,0 +1,16 @@
+package no.nav.dagpenger.mottak
+
+import no.bekk.bekkopen.person.FodselsnummerCalculator
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
+
+object PersonTestData {
+    private val dato = Date.from(
+        LocalDate.now().minusYears(20).atStartOfDay(
+            ZoneId.systemDefault()
+        ).toInstant()
+    )
+    val GENERERT_FØDSELSNUMMER by lazy { FodselsnummerCalculator.getFodselsnummerForDate(dato).toString() }
+    val GENERERT_DNUMMER by lazy { FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(dato).first().toString() }
+}

--- a/modell/src/test/kotlin/no/nav/dagpenger/mottak/e2e/AbstractEndeTilEndeTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/mottak/e2e/AbstractEndeTilEndeTest.kt
@@ -7,6 +7,7 @@ import no.nav.dagpenger.mottak.Aktivitetslogg.Aktivitet.Behov.Behovtype
 import no.nav.dagpenger.mottak.Innsending
 import no.nav.dagpenger.mottak.InnsendingObserver
 import no.nav.dagpenger.mottak.InnsendingTilstandType
+import no.nav.dagpenger.mottak.PersonTestData.GENERERT_FØDSELSNUMMER
 import no.nav.dagpenger.mottak.ReplayFerdigstillEvent
 import no.nav.dagpenger.mottak.meldinger.ArenaOppgaveOpprettet
 import no.nav.dagpenger.mottak.meldinger.Eksisterendesaker
@@ -31,7 +32,6 @@ abstract class AbstractEndeTilEndeTest {
 
     protected companion object {
         private const val NAVN = "TEST TESTEN"
-        private const val UNG_PERSON_FNR_2018 = "12020052345"
         private const val AKTØRID = "42"
         private const val JOURNALPOST_ID = "12345"
         private val mapper: ObjectMapper = jacksonObjectMapper()
@@ -197,7 +197,7 @@ abstract class AbstractEndeTilEndeTest {
         aktivitetslogg = Aktivitetslogg(),
         journalpostId = JOURNALPOST_ID,
         aktørId = AKTØRID,
-        fødselsnummer = UNG_PERSON_FNR_2018,
+        ident = GENERERT_FØDSELSNUMMER,
         norskTilknytning = true,
         navn = NAVN
     )

--- a/modell/src/test/kotlin/no/nav/dagpenger/mottak/meldinger/OppgavebenkTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/mottak/meldinger/OppgavebenkTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import no.nav.dagpenger.mottak.PersonTestData.GENERERT_FØDSELSNUMMER
 import no.nav.dagpenger.mottak.SøknadFakta
 import no.nav.dagpenger.mottak.erFornyetRettighet
 import no.nav.dagpenger.mottak.erGrenseArbeider
@@ -23,7 +24,7 @@ class OppgavebenkTest {
     private val person = PersonInformasjon.Person(
         "Test Navn",
         "12344",
-        "12345678901",
+        GENERERT_FØDSELSNUMMER,
         norskTilknytning = true,
         diskresjonskode = false
     )

--- a/modell/src/test/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjonTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjonTest.kt
@@ -1,6 +1,8 @@
 package no.nav.dagpenger.mottak.meldinger
 
 import no.nav.dagpenger.mottak.Aktivitetslogg
+import no.nav.dagpenger.mottak.PersonTestData.GENERERT_DNUMMER
+import no.nav.dagpenger.mottak.PersonTestData.GENERERT_FØDSELSNUMMER
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -10,17 +12,32 @@ import org.junit.jupiter.params.provider.ValueSource
 internal class PersonInformasjonTest {
 
     @ParameterizedTest
+    @ValueSource(strings = ["1234", "12345678901", "12020052345"])
+    fun `Skal ikke validere riktig hvis ikke det er gyldig fødselsnummer eller dnummer`(ident: String) {
+
+        val personInformasjon = PersonInformasjon(
+            Aktivitetslogg(),
+            journalpostId = "12345",
+            aktørId = "12345678",
+            ident = ident,
+            norskTilknytning = true,
+            navn = "Test Testen",
+            diskresjonskode = null
+        )
+        assertFalse(personInformasjon.validate())
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = ["STRENGT_FORTROLIG_UTLAND", "STRENGT_FORTROLIG"])
     fun `skal mappe diskresjonskoder`(kode: String) {
         val person = PersonInformasjon(
             Aktivitetslogg(),
             journalpostId = "12345",
             aktørId = "12345678",
-            fødselsnummer = "12345678901",
+            ident = GENERERT_FØDSELSNUMMER,
             norskTilknytning = true,
             navn = "Test Testen",
             diskresjonskode = kode
-
         )
         assertTrue(person.person().diskresjonskode, "Kode $kode")
     }
@@ -31,11 +48,25 @@ internal class PersonInformasjonTest {
             Aktivitetslogg(),
             journalpostId = "12345",
             aktørId = "12345678",
-            fødselsnummer = "12345678901",
+            ident = GENERERT_FØDSELSNUMMER,
             norskTilknytning = true,
             navn = "Test Testen",
             diskresjonskode = null
         )
         assertFalse(person.person().diskresjonskode)
+    }
+
+    @Test
+    fun `dnummer og fødselsnummersjekk`() {
+        val person = PersonInformasjon.Person(
+            aktørId = "12345678",
+            ident = GENERERT_DNUMMER,
+            norskTilknytning = true,
+            navn = "Test Testen",
+            diskresjonskode = false
+        )
+
+        assertTrue(person.erDnummer(), "Skal være dnummer")
+        assertFalse(person.copy(ident = GENERERT_FØDSELSNUMMER).erDnummer(), "Skal være fødselsnummer")
     }
 }

--- a/modell/src/test/kotlin/no/nav/dagpenger/mottak/serder/InnsendingDataTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/mottak/serder/InnsendingDataTest.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.mottak.serder
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.dagpenger.mottak.PersonTestData.GENERERT_FØDSELSNUMMER
 import no.nav.dagpenger.mottak.serder.InnsendingData.AktivitetsloggData
 import no.nav.dagpenger.mottak.serder.InnsendingData.ArenaSakData
 import no.nav.dagpenger.mottak.serder.InnsendingData.JournalpostData
@@ -16,7 +17,7 @@ import java.time.LocalDateTime
 internal class InnsendingDataTest {
     private val journalpostId = "ertyu"
     private val journalpostStatus = "aktiv"
-    private val fnr = "12345678910"
+    private val fnr = GENERERT_FØDSELSNUMMER
     private val registrertdato = LocalDateTime.now()
     private val dokumenter = listOf(
         DokumentInfoData(


### PR DESCRIPTION
Vi støtter ikke personer som har dnummer som er koblet til aktørid som ved en senere innsending har fått fødselsnummer tilknyttet samme aktørid.
Endret navn på attributt på person fra fødselsnummer til ident og validerer identnummer.


resolves navikt/dagpenger#875