### PR TITLE
Legg til unntak for syntetiske fnr/dnr

### DIFF
--- a/modell/src/main/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjon.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjon.kt
@@ -41,7 +41,7 @@ class PersonInformasjon(
     ) {
 
         init {
-            require(FodselsnummerValidator.isValid(ident)) { "Ikke gyldig ident" }
+            require(FodselsnummerValidator.isValid(ident) || erSyntetiskTestIdent()) { "Ikke gyldig ident" }
         }
 
         fun erDnummer() = ident.substring(0, 1).toInt() in 4..7
@@ -49,6 +49,8 @@ class PersonInformasjon(
         fun accept(visitor: PersonVisitor) {
             visitor.visitPerson(navn, aktørId, ident, norskTilknytning, diskresjonskode)
         }
+
+        private fun erSyntetiskTestIdent() = ident[2].toString() == "8"
     }
 }
 


### PR DESCRIPTION
I forbindelse med at Skattetaten og et samarbeid mellom offentlige aktører ønsker å innføre såkalte "syntetiske" identer (fnr/dnr) hvor måneden er +80 (også kalt 80-serie) må vi hoppe bukk over fnr-valideringa vår.

Burde vi gjøre dette kun i dev? Det høres ganske kålete ut å få til.