### PR TITLE
Godta identer fra syntetiske testpersoner.

### DIFF
--- a/modell/src/main/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjon.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjon.kt
@@ -37,11 +37,15 @@ class PersonInformasjon(
         val aktørId: String,
         val ident: String,
         val norskTilknytning: Boolean,
-        val diskresjonskode: Boolean
+        val diskresjonskode: Boolean,
     ) {
 
         init {
             require(FodselsnummerValidator.isValid(ident) || erSyntetiskTestIdent()) { "Ikke gyldig ident" }
+        }
+
+        private companion object {
+            const val SYNTETISK_MÅNED_OFFSET = 80
         }
 
         fun erDnummer() = ident.substring(0, 1).toInt() in 4..7
@@ -50,11 +54,23 @@ class PersonInformasjon(
             visitor.visitPerson(navn, aktørId, ident, norskTilknytning, diskresjonskode)
         }
 
-        private fun erSyntetiskTestIdent() = ident[2].toString() == "8"
+        private fun erSyntetiskTestIdent(): Boolean =
+            try {
+                val måned = ident.substring(2, 4).toInt()
+                (måned - SYNTETISK_MÅNED_OFFSET) in 1..12
+            } catch (err: NumberFormatException) {
+                false
+            }
     }
 }
 
 class PersonInformasjonIkkeFunnet(aktivitetslogg: Aktivitetslogg, private val journalpostId: String) :
     Hendelse(aktivitetslogg) {
     override fun journalpostId(): String = journalpostId
+}
+
+fun main() {
+    PersonInformasjon.Person(
+        "", "13907198019", "13907198019", true, false
+    )
 }

--- a/modell/src/main/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjon.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjon.kt
@@ -68,9 +68,3 @@ class PersonInformasjonIkkeFunnet(aktivitetslogg: Aktivitetslogg, private val jo
     Hendelse(aktivitetslogg) {
     override fun journalpostId(): String = journalpostId
 }
-
-fun main() {
-    PersonInformasjon.Person(
-        "", "13907198019", "13907198019", true, false
-    )
-}

--- a/modell/src/test/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjonTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/mottak/meldinger/PersonInformasjonTest.kt
@@ -6,6 +6,7 @@ import no.nav.dagpenger.mottak.PersonTestData.GENERERT_FØDSELSNUMMER
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -68,5 +69,18 @@ internal class PersonInformasjonTest {
 
         assertTrue(person.erDnummer(), "Skal være dnummer")
         assertFalse(person.copy(ident = GENERERT_FØDSELSNUMMER).erDnummer(), "Skal være fødselsnummer")
+    }
+
+    @Test
+    fun `skal validere identer fra syntetiske testpersoner`() {
+        assertDoesNotThrow {
+            PersonInformasjon.Person(
+                aktørId = "12345678",
+                ident = "13907198019",
+                norskTilknytning = true,
+                navn = "Test Testen",
+                diskresjonskode = false
+            )
+        }
     }
 }


### PR DESCRIPTION
Ser vi opprettet mange manuelle gosys saker i test fordi vi ikke godtar alle varianter av syntestiske testversjoner.

(Utvidelse av https://github.com/navikt/dp-mottak/pull/36 ) 


