### PR TITLE
DAG 761/Ruting egne ansatte

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/mottak/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mottak/ApplicationBuilder.kt
@@ -12,6 +12,8 @@ import no.nav.dagpenger.mottak.behov.journalpost.SafClient
 import no.nav.dagpenger.mottak.behov.journalpost.SøknadsdataBehovLøser
 import no.nav.dagpenger.mottak.behov.person.PdlPersondataOppslag
 import no.nav.dagpenger.mottak.behov.person.PersondataBehovLøser
+import no.nav.dagpenger.mottak.behov.person.SkjermingOppslag
+import no.nav.dagpenger.mottak.behov.person.createPersonOppslag
 import no.nav.dagpenger.mottak.behov.saksbehandling.arena.ArenaApiClient
 import no.nav.dagpenger.mottak.behov.saksbehandling.arena.ArenaBehovLøser
 import no.nav.dagpenger.mottak.behov.saksbehandling.gosys.GosysProxyClient
@@ -71,7 +73,10 @@ internal class ApplicationBuilder(env: Map<String, String>) : RapidsConnection.S
             JournalpostBehovLøser(safClient, this)
             OppdaterJournalpostBehovLøser(journalpostApiClient, this)
             FerdigstillJournalpostBehovLøser(journalpostApiClient, this)
-            PersondataBehovLøser(PdlPersondataOppslag(Config.properties), this)
+            PersondataBehovLøser(
+                createPersonOppslag(PdlPersondataOppslag(Config.properties), SkjermingOppslag(Config.properties)),
+                this
+            )
             SøknadsdataBehovLøser(safClient, this)
             MinsteinntektVurderingLøser(
                 regelApiClient = regelApiClient,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/mottak/Config.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mottak/Config.kt
@@ -36,6 +36,8 @@ internal object Config {
             "KAFKA_RESET_POLICY" to "latest",
             "PDL_API_SCOPE" to "api://dev-fss.pdl.pdl-api/.default",
             "PDL_API_URL" to "https://pdl-api.dev-fss-pub.nais.io",
+            "SKJERMING_API_SCOPE" to "api://dev-gcp.nom.skjermede-personer-pip/.default",
+            "SKJERMING_API_URL" to "http://skjermede-personer-pip.nom/skjermet",
             "UNLEASH_URL" to "https://unleash.nais.io/api/",
             "AZURE_OPENID_CONFIG_ISSUER" to "azureAd",
             "AZURE_APP_CLIENT_ID" to "azureClientId",
@@ -49,6 +51,7 @@ internal object Config {
             "DP_PROXY_URL" to "https://dp-proxy.prod-fss-pub.nais.io",
             "PDL_API_SCOPE" to "api://prod-fss.pdl.pdl-api/.default",
             "PDL_API_URL" to "https://pdl-api.prod-fss-pub.nais.io",
+            "SKJERMING_API_SCOPE" to "api://prod-gcp.nom.skjermede-personer-pip/.default",
         )
     )
 
@@ -75,6 +78,9 @@ internal object Config {
     val Configuration.pdlApiTokenProvider: () -> String by lazy {
         { cachedTokenProvider.clientCredentials(properties[Key("PDL_API_SCOPE", stringType)]).accessToken }
     }
+    val Configuration.skjermingApiTokenProvider: () -> String by lazy {
+        { cachedTokenProvider.clientCredentials(properties[Key("SKJERMING_API_SCOPE", stringType)]).accessToken }
+    }
 
     val kafkaProducerProperties: Properties by lazy {
         Properties().apply {
@@ -89,6 +95,7 @@ internal object Config {
             put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, properties[Key("KAFKA_CREDSTORE_PASSWORD", stringType)])
         }
     }
+
     object AzureAd {
         const val name = "azureAd"
         val audience = properties[Key("AZURE_APP_CLIENT_ID", stringType)]
@@ -96,6 +103,7 @@ internal object Config {
         val jwksURI = properties[Key("AZURE_OPENID_CONFIG_JWKS_URI", stringType)]
     }
 
+    fun Configuration.skjermingApiUrl() = this[Key("SKJERMING_API_URL", stringType)]
     fun Configuration.dpProxyUrl() = this[Key("DP_PROXY_URL", stringType)]
     fun Configuration.pdlApiUrl() = this[Key("PDL_API_URL", stringType)]
     fun unleash() = DefaultUnleash(unleashConfig(), ByClusterStrategy(ByClusterStrategy.Cluster.current))

--- a/mediator/src/main/kotlin/no/nav/dagpenger/mottak/behov/person/Pdl.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mottak/behov/person/Pdl.kt
@@ -25,7 +25,7 @@ import no.nav.dagpenger.mottak.behov.JsonMapper.jacksonJsonAdapter
 
 private val sikkerlogg = KotlinLogging.logger("tjenestekall.Pdl")
 
-internal class PdlPersondataOppslag(config: Configuration) : PersonOppslag {
+internal class PdlPersondataOppslag(config: Configuration) {
     private val tokenProvider = config.pdlApiTokenProvider
     private val pdlClient = HttpClient() {
         expectSuccess = true
@@ -37,7 +37,7 @@ internal class PdlPersondataOppslag(config: Configuration) : PersonOppslag {
         }
     }
 
-    override suspend fun hentPerson(id: String): Pdl.Person? = pdlClient.request {
+    suspend fun hentPerson(id: String): Pdl.Person? = pdlClient.request {
         header(HttpHeaders.Authorization, "Bearer ${tokenProvider.invoke()}")
         method = HttpMethod.Post
         setBody(PersonQuery(id).toJson().also { sikkerlogg.info { "Forsøker å hente person med id $id fra PDL" } })

--- a/mediator/src/main/kotlin/no/nav/dagpenger/mottak/behov/person/PersonOppslag.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mottak/behov/person/PersonOppslag.kt
@@ -1,5 +1,46 @@
 package no.nav.dagpenger.mottak.behov.person
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import mu.KotlinLogging
+
+private val logg = KotlinLogging.logger {}
+private val sikkerlogg = KotlinLogging.logger("tjenestekall.mottak.personoppslag")
+
 internal interface PersonOppslag {
-    suspend fun hentPerson(id: String): Pdl.Person?
+    suspend fun hentPerson(id: String): Person?
+    data class Person(
+        val navn: String,
+        val aktørId: String,
+        val fødselsnummer: String,
+        val norskTilknytning: Boolean,
+        val diskresjonskode: String?,
+        val egenAnsatt: Boolean?
+    )
+}
+
+internal fun createPersonOppslag(pdl: PdlPersondataOppslag, skjerming: SkjermingOppslag): PersonOppslag {
+    return object : PersonOppslag {
+        override suspend fun hentPerson(id: String): PersonOppslag.Person? {
+            return withContext(Dispatchers.IO) {
+                val pdlPerson = async { pdl.hentPerson(id) }
+                val egenAnsatt = async { skjerming.egenAnsatt(id) }.await().onFailure {
+                    logg.error(it) { "Feil ved oppslag mot skjerming" }
+                    sikkerlogg.error { "Feil ved oppslag mot skjerming for fødsenummer: $id" }
+                }.getOrNull()
+
+                pdlPerson.await()?.let {
+                    PersonOppslag.Person(
+                        navn = it.navn,
+                        aktørId = it.aktørId,
+                        fødselsnummer = it.fødselsnummer,
+                        norskTilknytning = it.norskTilknytning,
+                        diskresjonskode = it.diskresjonskode,
+                        egenAnsatt = egenAnsatt
+                    )
+                }
+            }
+        }
+    }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/mottak/behov/person/SkjermingOppslag.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mottak/behov/person/SkjermingOppslag.kt
@@ -1,0 +1,35 @@
+package no.nav.dagpenger.mottak.behov.person
+
+import com.natpryce.konfig.Configuration
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import no.nav.dagpenger.mottak.Config.skjermingApiTokenProvider
+import no.nav.dagpenger.mottak.Config.skjermingApiUrl
+
+internal class SkjermingOppslag(config: Configuration) {
+    private val tokenProvider = config.skjermingApiTokenProvider
+    private val httpClient by lazy {
+        HttpClient(CIO) {
+            expectSuccess = true
+            install(DefaultRequest) {
+                this.url(config.skjermingApiUrl())
+                header("Content-Type", "application/json")
+                header(HttpHeaders.Authorization, "Bearer ${tokenProvider.invoke()}")
+            }
+        }
+    }
+
+    suspend fun egenAnsatt(id: String): Result<Boolean> {
+        return kotlin.runCatching {
+            httpClient.post {
+                this.setBody("""{"personident":"$id"}""")
+            }.bodyAsText().toBoolean()
+        }
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mottak/behov/person/PersonOppslagTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mottak/behov/person/PersonOppslagTest.kt
@@ -1,0 +1,54 @@
+package no.nav.dagpenger.mottak.behov.person
+
+import io.mockk.coEvery
+import io.mockk.mockkClass
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class PersonOppslagTest {
+    private val id = "id"
+    private val id2 = "id2"
+    private val pdlMock = mockkClass(type = PdlPersondataOppslag::class).also {
+        coEvery { it.hentPerson(any()) } returns Pdl.Person(
+            navn = "navn",
+            aktørId = "aktørId",
+            fødselsnummer = "fnr",
+            norskTilknytning = false,
+            diskresjonskode = "kode"
+        )
+    }
+    private val skjermingMock = mockkClass(type = SkjermingOppslag::class).also {
+        coEvery { it.egenAnsatt(id) } returns Result.success(true)
+        coEvery { it.egenAnsatt(id2) } returns Result.failure(Throwable("test"))
+    }
+
+    @Test
+    fun `skal hente person info fra forskjellige kilder`() {
+        createPersonOppslag(pdl = pdlMock, skjerming = skjermingMock).let { personOppslag ->
+            runBlocking {
+                personOppslag.hentPerson(id).let { person ->
+                    requireNotNull(person)
+                    assertEquals("navn", person.navn)
+                    assertEquals("aktørId", person.aktørId)
+                    assertEquals("fnr", person.fødselsnummer)
+                    assertEquals(false, person.norskTilknytning)
+                    assertEquals("kode", person.diskresjonskode)
+                    assertEquals(true, person.egenAnsatt)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Håndterer at kall mot skjermings oppslag feiler`() {
+        createPersonOppslag(pdl = pdlMock, skjerming = skjermingMock).let { personOppslag ->
+            runBlocking {
+                personOppslag.hentPerson(id2).let { person ->
+                    requireNotNull(person)
+                    assertEquals(null, person.egenAnsatt)
+                }
+            }
+        }
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mottak/behov/person/PersondataBehovLøserTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mottak/behov/person/PersondataBehovLøserTest.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.mottak.behov.person
 
+import no.nav.dagpenger.mottak.behov.person.PersonOppslag.Person
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -25,12 +26,13 @@ internal class PersondataBehovLøserTest {
         PersondataBehovLøser(
             rapidsConnection = testRapid,
             personOppslag = object : PersonOppslag {
-                override suspend fun hentPerson(id: String): Pdl.Person = Pdl.Person(
+                override suspend fun hentPerson(id: String): Person = Person(
                     navn = "Hubba bubba",
                     aktørId = "12345678",
                     fødselsnummer = "1234567891",
                     norskTilknytning = true,
-                    diskresjonskode = "diskresjonskode"
+                    diskresjonskode = "diskresjonskode",
+                    egenAnsatt = false
                 )
             }
         )
@@ -41,6 +43,7 @@ internal class PersondataBehovLøserTest {
             assertEquals("1234567891", field(0, "@løsning")["Persondata"]["fødselsnummer"].asText())
             assertEquals("true", field(0, "@løsning")["Persondata"]["norskTilknytning"].asText())
             assertEquals("diskresjonskode", field(0, "@løsning")["Persondata"]["diskresjonskode"].asText())
+            assertEquals(false, field(0, "@løsning")["Persondata"]["egenAnsatt"].asBoolean())
         }
     }
 
@@ -49,7 +52,7 @@ internal class PersondataBehovLøserTest {
         PersondataBehovLøser(
             rapidsConnection = testRapid,
             personOppslag = object : PersonOppslag {
-                override suspend fun hentPerson(id: String): Pdl.Person? = null
+                override suspend fun hentPerson(id: String): Person? = null
             }
         )
         testRapid.sendTestMessage(persondataBehov())

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -36,6 +36,9 @@ spec:
       enabled: true
   accessPolicy:
     outbound:
+      rules:
+       - application: nom
+         namespace: skjermede-personer-pip
       external:
         - host: {{ DP_PROXY_HOST }}
     inbound:


### PR DESCRIPTION
Slå opp skjerming info når vi henter ut info om personer.

Skjerming i denne konteksten er rett og slett om brukeren er egen ansatt eller ei.

