### PR TITLE
Håndter pakker der persondata er null

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/mottak/tjenester/PersondataMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/mottak/tjenester/PersondataMottak.kt
@@ -14,6 +14,7 @@ import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.asLocalDateTime
 
 private val logg = KotlinLogging.logger {}
+
 internal class PersondataMottak(
     private val innsendingMediator: InnsendingMediator,
     rapidsConnection: RapidsConnection
@@ -25,7 +26,7 @@ internal class PersondataMottak(
         River(rapidsConnection).apply {
             validate { it.requireValue("@event_name", "behov") }
             validate { it.require("@opprettet", JsonNode::asLocalDateTime) }
-            validate { it.requireKey(løsning) }
+            validate { it.require(key = løsning, parser = {}) }
             validate { it.requireKey("journalpostId") }
         }.register(this)
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/mottak/tjenester/PersondataMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/mottak/tjenester/PersondataMottakTest.kt
@@ -1,29 +1,39 @@
 package no.nav.dagpenger.mottak.tjenester
 
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
 import no.nav.dagpenger.mottak.InnsendingMediator
-import no.nav.dagpenger.mottak.db.InMemoryInnsendingRepository
-import no.nav.dagpenger.mottak.e2e.TestObservatør
+import no.nav.dagpenger.mottak.meldinger.PersonInformasjonIkkeFunnet
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import org.junit.Before
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.util.UUID
 
 class PersondataMottakTest {
-    val testRapid = TestRapid()
-    private val innsendingRepository = InMemoryInnsendingRepository()
-    private val observatør = TestObservatør()
-    private val innsendingMediator = InnsendingMediator(
-        innsendingRepository = innsendingRepository,
-        rapidsConnection = testRapid,
-        observatører = listOf(observatør)
-    )
+    private val testRapid = TestRapid()
+    private val innsendingMediator = mockk<InnsendingMediator>().also {
+        every { it.håndter(any<PersonInformasjonIkkeFunnet>()) } just Runs
+    }
+
     init {
         PersondataMottak(innsendingMediator, testRapid)
+    }
+
+    @Before
+    fun setup() {
+        testRapid.reset()
     }
 
     @Test
     fun `håndterer svar med null`() {
         testRapid.sendTestMessage(persondataMottattHendelse())
+        verify(exactly = 1) {
+            innsendingMediator.håndter(any<PersonInformasjonIkkeFunnet>())
+        }
     }
 
     //language=JSON


### PR DESCRIPTION
Blast from the past @geiralund 

Vi skipper pakker der person data er null. Likevel har vi håndtering av PersonIkkeFunnet, så lurer på om det er en bug eller feature :) 

PR antar at det er en bug, og vil ikke lengre skippe pakker